### PR TITLE
Fix the majority of verification race conditions

### DIFF
--- a/src/verification/managers/verifyUser.js
+++ b/src/verification/managers/verifyUser.js
@@ -42,6 +42,11 @@ async function verifyUser(ticket, verifier, resolve, reject) {
         return;
     }
 
+    if (applicant.roles.cache.has(config.roles.verified)) {
+        await reject('User has already been verified');
+        return;
+    }
+
     // verify user
     await verify(applicant);
 


### PR DESCRIPTION
There is currently a high potential for race conditions when multiple verifiers attempt to verify a user at the same time. This PR fixes the majority of these cases

Data races can probably still occur in the following cases:
- If Discord is still adding the role when we fetch the user for the second time
- If we don't all verify, for example if someone does a kick and someone else does a verify

These are substantially less likely than the common case, which has happened several times now

This was ported over from https://github.com/TransPlace-Devs/theo/pull/5