### PR TITLE
Support configuring selfies channel in TP-style verification

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -208,7 +208,9 @@ const development = {
             },
             invite: 'https://google.com',
             proxy: GAproxy,
-            rulesMessages: GARulesMessages,
+            rulesMessages: TPRulesMessages({
+                selfiesChannelId: '1258669733851562005',
+            }),
         },
         '981615050664075404': {
             // TPSupporters
@@ -251,7 +253,9 @@ const development = {
             },
             invite: 'https://yahoo.com',
             proxy: TPproxy,
-            rulesMessages: TPRulesMessages,
+            rulesMessages: TPRulesMessages({
+                selfiesChannelId: '1494008807276281897',
+            }),
         },
     },
 };
@@ -320,7 +324,9 @@ const production = {
             },
             invite: 'https://discord.gg/TransPlace',
             proxy: TPproxy,
-            rulesMessages: TPRulesMessages,
+            rulesMessages: TPRulesMessages({
+                selfiesChannelId: '1037517248862101504',
+            }),
         },
         '1087014898199969873': {
             // EnbyPlace
@@ -378,7 +384,9 @@ const production = {
             },
             invite: 'https://discord.gg/xt8WqnGffb',
             proxy: TPproxy,
-            rulesMessages: TPRulesMessages,
+            rulesMessages: TPRulesMessages({
+                selfiesChannelId: '1376455776993935481',
+            }),
         },
         '638480381552754730': {
             // Transonance
@@ -437,7 +445,9 @@ const production = {
             },
             invite: 'https://discord.gg/QhTDQsyeD6',
             proxy: TPproxy,
-            rulesMessages: TPRulesMessages,
+            rulesMessages: TPRulesMessages({
+                selfiesChannelId: null,
+            }),
         },
         '1116634030834733077': {
             // TransDice!
@@ -475,7 +485,9 @@ const production = {
             },
             invite: 'https://discord.gg/YUJM2Qg55q',
             proxy: TPproxy,
-            rulesMessages: TPRulesMessages,
+            rulesMessages: TPRulesMessages({
+                selfiesChannelId: null,
+            }),
         },
         '1135300957572431902': {
             // Gender Anarchy

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -3,7 +3,7 @@ const TPRulesImgEmbed = {
     image: { url: 'https://raw.githubusercontent.com/TransGG/assets/refs/heads/main/tp-server-rules-header.png' },
 };
 
-const TPRulesEmbed = {
+const TPRulesEmbed = ({ selfiesChannelId }) => ({
     color: 0xDF585B,
     title: 'Rules',
     fields: [
@@ -49,7 +49,7 @@ const TPRulesEmbed = {
         },
         {
             name: '`11`. **Keep on-topic in all channels.**',
-            value: '> We understand conversations naturally drift; however, if they do not self-correct after a while, a mod may step in to help do so.\n\n> *As well*, selfies are to be shared only in <#+1037517248862101504> [**#selfies**]. This is to ensure the safety of all of our members. Access to the #selfies channel will be granted after meeting server activity requirements.',
+            value: `> We understand conversations naturally drift; however, if they do not self-correct after a while, a mod may step in to help do so.${selfiesChannelId ? `\n\n> *As well*, selfies are to be shared only in <#${selfiesChannelId}> (**#selfies**). This is to ensure the safety of all of our members. Access to the **#selfies** channel will be granted after meeting server activity requirements.` : ''}`,
         },
         {
             name: '`12`. **Keep all conversations in English.**',
@@ -61,7 +61,7 @@ const TPRulesEmbed = {
         },
     ],
     image: { url: 'https://raw.githubusercontent.com/TransGG/assets/refs/heads/main/embed-sizer.png' },
-};
+})
 
 const notesReportEmbed = {
     color: 0xDF585B,
@@ -141,8 +141,8 @@ const GAMentalHealthEmbed = {
     image: { url: 'https://raw.githubusercontent.com/TransGG/assets/refs/heads/main/embed-sizer.png' },
 };
 
-export const TPRulesMessages = [
-    { embeds: [TPRulesImgEmbed, TPRulesEmbed] },
+export const TPRulesMessages = (config) => [
+    { embeds: [TPRulesImgEmbed, TPRulesEmbed(config)] },
     { embeds: [notesReportEmbed, mentalHealthEmbed] },
 ];
 


### PR DESCRIPTION
Currently, rule 11 always shows the channel ID for TP's selfies channel. This linking also does not actually work.

This PR supports configuring the channel ID per server as well as leaving it unspecified to remove that part from the rule, as not all servers following the TP template have the selfies channel rule.

> [!TIP]
> This has been tested in DevPlace! and TransPlace! Supporters. To test it yourself, set your bot token as `TOKEN` in `.env` and temporarily set `development.clientId`, then run `npm start` and use `/sendwelcome` to send the message in one of the testing servers.