### PR TITLE
Include mod in action outputs in the thread

### DIFF
--- a/src/verification/managers/denyVerification.js
+++ b/src/verification/managers/denyVerification.js
@@ -1,6 +1,6 @@
-import { bold, codeBlock } from 'discord.js';
+import { bold, codeBlock, userMention } from 'discord.js';
 import { verbose } from '../../config/out.js';
-import { parseApplicantId } from '../controllers/ticket.js';
+import { parseApplicantId, sendMessage } from '../controllers/ticket.js';
 import { fetchUser, resolveUser } from '../controllers/user.js';
 import VerificationError from '../verificationError.js';
 import ban from './ban.js';
@@ -139,6 +139,7 @@ async function denyVerification(
             closeType = CloseReason.unknown;
             break;
     }
+    await sendMessage(ticket, `${userMention(verifier.id)} has denied this verification`);
     await closeTicket(ticket, closeType);
 }
 

--- a/src/verification/managers/verifyUser.js
+++ b/src/verification/managers/verifyUser.js
@@ -76,7 +76,7 @@ async function verifyUser(ticket, verifier, resolve, reject, type) {
     await Promise.all(sendMessages);
 
     // success
-    await resolve(`${userMention(applicant.id)} has been verified`);
+    await resolve(`${userMention(verifier.id)} verified ${userMention(applicant.id)}`);
 
     // close ticket (has to happen after resolution)
     await closeTicket(ticket);


### PR DESCRIPTION
Right now, figuring out which mod approved/denied a verification and looking at the verification itself requires finding two separate pieces of information. We can streamline this a bit by simply outputting the acting mod in the ticket.

Note that this message is generated after the action is taken so users being approved will be locked out by receiving the verified role and denied users will be removed from the server first. That said, showing the acting mod to approved users isn't much of a big deal as usually it's the person asking them questions and they will likely assume that anyway.